### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "concurrently": "^5.2.0",
     "cross-env": "^7.0.2",
     "full-icu": "^1.3.1",
+    "nodemon": "^2.0.4",
     "tsoa": "^3.2.1",
     "typescript": "^3.9.5"
   },
@@ -53,7 +54,6 @@
     "method-override": "^3.0.0",
     "morgan": "^1.10.0",
     "node-cache": "^5.1.1",
-    "nodemon": "^2.0.4",
     "path-to-regexp": "^6.1.0",
     "pg": "^8.2.1",
     "pg-hstore": "^2.3.3",


### PR DESCRIPTION
Move `nodemon` to `devDependencies`
Maybe another ones need to go to `devDependencies` because is only used in dev environment but in build they is not necessaries:
```json:
    "@babel/polyfill": "^7.10.1",
    "@types/express": "^4.17.6",
    "@types/jest": "^26.0.0",
    "@types/supertest": "^2.0.9",
```